### PR TITLE
Define Basic Resources

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,16 @@
+# Bloom
+a software-powered education system. ⬢‿⬢
+
+This repository is a self-contained service, providing everything necessary to
+run an instance of Bloom.  Community not included.
+
+## Quick Start
+`npm install && node bloom.js`
+
+## Developer Guide
+We're using Maki to build a full-stack application from a simple set of type
+definitions.  If you want to hack on Bloom, you'll want to modify Maki directly.
+
+1. Fork `martindale/maki` and get a working copy locally.
+2. In your `maki` folder, run `npm link` to expose your local copy.
+3. In the `bloom` folder, run `npm link maki` to use that copy.

--- a/service/bloom.js
+++ b/service/bloom.js
@@ -1,0 +1,17 @@
+// Bloom.
+// Let's start by setting some configuration.
+var config = require('./config');
+
+// Acquire an instance of Maki.
+var Maki = require('maki');
+var bloom = new Maki(config);
+
+// Define our "types".
+// In Fabric, these are versioned definitions, content-addressable and usually
+// only modifiable by the application developers.
+bloom.define('Lesson', require('./resources/lesson'));
+bloom.define('Event', require('./resources/event'));
+bloom.define('Atom', require('./resources/atom'));
+
+// Start our engine.
+bloom.start();

--- a/service/config/index.js
+++ b/service/config/index.js
@@ -1,0 +1,18 @@
+module.exports = {
+  service: {
+    icon: 'leaf',
+    name: 'bloom',
+    namespace: 'bloom',
+    mission: 'a software-powered education system. ⬢‿⬢',
+    description: 'Bloom is an alternative to traditional education, by way of interactive, discoverable, engaging examples.'
+  },
+  services: {
+    http: {
+      port: 2300
+    }
+  },
+  // TODO: migrate to `storage`
+  database: {
+    name: 'bloom'
+  }
+}

--- a/service/package.json
+++ b/service/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "bloom",
+  "version": "0.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/service/package.json
+++ b/service/package.json
@@ -1,11 +1,14 @@
 {
   "name": "bloom",
-  "version": "0.0.0",
-  "description": "",
+  "version": "0.0.0-dev",
+  "description": "a software-powered education system. ⬢‿⬢",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
-  "license": "ISC"
+  "author": "Bloom",
+  "license": "MIT",
+  "dependencies": {
+    "maki": "git://github.com/martindale/maki#master"
+  }
 }

--- a/service/resources/atom.js
+++ b/service/resources/atom.js
@@ -1,0 +1,10 @@
+var Atom = {
+  public: false,
+  icon: 'cube',
+  description: 'A composable unit of knowledge',
+  attributes: {
+    content: { type: String }
+  }
+};
+
+module.exports = Atom;

--- a/service/resources/event.js
+++ b/service/resources/event.js
@@ -1,0 +1,11 @@
+var Event = {
+  public: false,
+  icon: 'clock',
+  description: 'A step in a Lesson',
+  attributes: {
+    time: { type: Number },
+    resource: { type: String , ref: 'Molecule' }
+  }
+};
+
+module.exports = Event;

--- a/service/resources/lesson.js
+++ b/service/resources/lesson.js
@@ -1,0 +1,11 @@
+var Lesson = {
+  icon: 'university',
+  description: 'A thing you can learn',
+  attributes: {
+    name: { type: String , max: 140 },
+    description: { type: String },
+    events: [ { type: String , ref: 'Event' } ]
+  }
+};
+
+module.exports = Lesson;


### PR DESCRIPTION
This adds a new directory, `service/`, which contains a Maki-rolled set of definitions for the basic types, or "resources", that Bloom will be built on top of.